### PR TITLE
Add support for unlocking migration support on vGPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,13 @@ cuda_enabled = 1
 frl_enabled = 0
 ```
 
+If you want to enable VM migration or snapshotting, you must 
+recompile the `nvidia-vgpu-vfio` kernel module with `NV_KVM_MIGRATION_UAPI` 
+equal to 1. Then, create the file `/etc/vgpu_unlock/config.toml` and add the 
+following:
+
+```toml
+unlock_migration = true
+```
+
 Happy hacking!

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,12 +7,18 @@ impl Defaults {
     const fn unlock() -> bool {
         true
     }
+    #[inline]
+    const fn unlock_migration() -> bool {
+        false
+    }
 }
 
 #[derive(Deserialize)]
 pub struct Config {
     #[serde(default = "Defaults::unlock")]
     pub unlock: bool,
+    #[serde(default = "Defaults::unlock_migration")]
+    pub unlock_migration: bool,
 }
 
 impl Default for Config {
@@ -20,6 +26,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             unlock: Defaults::unlock(),
+            unlock_migration: Defaults::unlock_migration(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,9 @@ const OP_READ_PCI_ID: u32 = 0x20801801;
 /// `result` is a pointer to `VgpuConfig`.
 const OP_READ_VGPU_CFG: u32 = 0xa0820102;
 
+/// `result` is a pointer to `bool`.
+const OP_READ_VGPU_MIG_CAP: u32 = 0xa0810112;
+
 /// `nvidia-vgpu-mgr` expects this value for a vGPU capable GPU.
 const DEV_TYPE_VGPU_CAPABLE: u32 = 3;
 
@@ -340,9 +343,15 @@ pub unsafe extern "C" fn ioctl(fd: RawFd, request: c_ulong, argp: *mut c_void) -
 
             // Set device type to vGPU capable.
             *dev_type_ptr = DEV_TYPE_VGPU_CAPABLE;
-        }
+        },
+        OP_READ_VGPU_MIG_CAP if CONFIG.unlock_migration => {
+            let mig_enabled: *mut bool = io_data.result.cast();
+
+            *mig_enabled = true;
+        },
         _ => {}
     }
+
 
     if io_data.status == STATUS_OK {
         match io_data.op_type {


### PR DESCRIPTION
At the moment, NVIDIA vGPU, whether consumer or officially supported GPU, does not support migration or snapshotting of VMs on KVM as the feature seems to be disabled in software. This pull request unlocks migration and snapshotting and puts it behind a new configuration flag, `enable_migration`. 

The reason for the flag is because currently enabling migration for KVM is contingent on recompiling the `nvidia-vgpu-vfio` kernel module with the flag `NV_KVM_MIGRATION_UAPI=1`. I have tested this code to work successfully, including with the flags, and updated the documentation in `README.md` to reflect these changes accordingly.