### PR TITLE
Add [vm.<id>] section as syntactic sugar for proxmox users

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ libc = "0.2.102"
 parking_lot = "0.11.2"
 serde = { version = "1.0.130", features = ["derive"] }
 toml = "0.5.8"
+
+[features]
+# Feature flag to enable syntactic sugar for proxmox users
+proxmox = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ toml = "0.5.8"
 [features]
 # Feature flag to enable syntactic sugar for proxmox users
 proxmox = []
+default = ["proxmox"]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,8 @@
 use std::fmt;
 
+#[cfg(feature = "proxmox")]
+use crate::uuid::Uuid;
+
 #[derive(Clone, Copy)]
 #[repr(C, align(8))]
 pub struct AlignedU64(pub u64);
@@ -16,4 +19,27 @@ impl fmt::LowerHex for AlignedU64 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(&self.0, f)
     }
+}
+
+#[cfg(feature = "proxmox")]
+/// Extracts the VMID from the last segment of a mdev uuid
+///
+/// For example, for this uuid 00000000-0000-0000-0000-000000000100
+/// it would extract the number 100
+///
+/// All except the last segment must be zero
+pub fn uuid_to_vmid(uuid: Uuid) -> Option<u64> {
+    // Ensure that the first parts of the uuid are only 0
+    if uuid.0 != 0 || uuid.1 != 0 || uuid.2 != 0 || uuid.3[0] != 0 || uuid.3[1] != 0 {
+        return None;
+    }
+
+    // Format the last segment of the uuid
+    let s = format!(
+        "{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        uuid.3[2], uuid.3[3], uuid.3[4], uuid.3[5], uuid.3[6], uuid.3[7]
+    );
+
+    // Parse it as a normal decimal number to get the right vm id
+    s.parse().ok()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,13 +21,13 @@ impl fmt::LowerHex for AlignedU64 {
     }
 }
 
-#[cfg(feature = "proxmox")]
 /// Extracts the VMID from the last segment of a mdev uuid
 ///
 /// For example, for this uuid 00000000-0000-0000-0000-000000000100
 /// it would extract the number 100
 ///
 /// All except the last segment must be zero
+#[cfg(feature = "proxmox")]
 pub fn uuid_to_vmid(uuid: Uuid) -> Option<u64> {
     // Ensure that the first parts of the uuid are only 0
     if uuid.0 != 0 || uuid.1 != 0 || uuid.2 != 0 || uuid.3[0] != 0 || uuid.3[1] != 0 {


### PR DESCRIPTION
This pull request improves the user experience for proxmox users by allowing to specify per-VM overrides using a new `[vm.<id>]`
 section.
The usual way to do per-VM overrides was by creating a section like this (in the example for the VM with id 100):
```toml
[mdev.00000000-0000-0000-0000-000000000100]
frl_enabled = 0
```

Many users had problems with the long uuid string, and now they can do this instead (again, for a VM with the id 100):
```toml
[vm.100]
frl_enabled = 0
```

Now, proxmox users don't have to bother with any uuids anymore :)