### PR TITLE
lib: Add handling of NV0000_CTRL_CMD_VGPU_CREATE_DEVICE for 17.0 host driver

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@ use crate::config::Config;
 use crate::format::WideCharFormat;
 use crate::log::{error, info};
 use crate::nvidia::ctrl0000vgpu::{
-    Nv0000CtrlVgpuGetStartDataParams, NV0000_CTRL_CMD_VGPU_GET_START_DATA,
-    Nv0000CtrlVgpuCreateDeviceParams, NV0000_CTRL_CMD_VGPU_CREATE_DEVICE,
+    Nv0000CtrlVgpuCreateDeviceParams, Nv0000CtrlVgpuGetStartDataParams,
+    NV0000_CTRL_CMD_VGPU_CREATE_DEVICE, NV0000_CTRL_CMD_VGPU_GET_START_DATA,
 };
 use crate::nvidia::ctrl0080gpu::{
     Nv0080CtrlGpuGetVirtualizationModeParams, NV0080_CTRL_CMD_GPU_GET_VIRTUALIZATION_MODE,
@@ -425,20 +425,19 @@ pub unsafe extern "C" fn ioctl(fd: RawFd, request: c_ulong, argp: *mut c_void) -
                     NV0000_CTRL_CMD_VGPU_GET_START_DATA,
                     Nv0000CtrlVgpuGetStartDataParams
                 ) =>
-	    {
+            {
                 let config: &Nv0000CtrlVgpuGetStartDataParams = &*io_data.params.cast();
-	        info!("Nv0000CtrlVgpuGetStartDataParams: {:#?}", config);
+                info!("Nv0000CtrlVgpuGetStartDataParams: {:#?}", config);
 
-               	*LAST_MDEV_UUID.lock() = Some(config.mdev_uuid);
+                *LAST_MDEV_UUID.lock() = Some(config.mdev_uuid);
             }
-    	    NV0000_CTRL_CMD_VGPU_CREATE_DEVICE => {
-		// 17.0 driver provides mdev uuid as vgpu_name in this command
-		let params: &mut Nv0000CtrlVgpuCreateDeviceParams =
-                    &mut *io_data.params.cast();
-	        info!("Nv0000CtrlVgpuCreateDeviceParams: {:#?}", params);
+            NV0000_CTRL_CMD_VGPU_CREATE_DEVICE => {
+                // 17.0 driver provides mdev uuid as vgpu_name in this command
+                let params: &mut Nv0000CtrlVgpuCreateDeviceParams = &mut *io_data.params.cast();
+                info!("Nv0000CtrlVgpuCreateDeviceParams: {:#?}", params);
 
-              	*LAST_MDEV_UUID.lock() = Some(params.vgpu_name);
-	    }
+                *LAST_MDEV_UUID.lock() = Some(params.vgpu_name);
+            }
             NVA081_CTRL_CMD_VGPU_CONFIG_GET_VGPU_TYPE_INFO => {
                 // 17.0 driver sends larger struct with size 5096 bytes. Only extra members added at the end,
                 // nothing in between or changed, so accessing the larger struct is "safe"
@@ -466,7 +465,10 @@ pub unsafe extern "C" fn ioctl(fd: RawFd, request: c_ulong, argp: *mut c_void) -
             {
                 let params: &mut NvA082CtrlCmdHostVgpuDeviceGetVgpuTypeInfoParams =
                     &mut *io_data.params.cast();
-                info!("NvA082CtrlCmdHostVgpuDeviceGetVgpuTypeInfoParams: {:#?}", params);
+                info!(
+                    "NvA082CtrlCmdHostVgpuDeviceGetVgpuTypeInfoParams: {:#?}",
+                    params
+                );
 
                 if !handle_profile_override(params) {
                     error!("Failed to apply profile override");
@@ -545,9 +547,9 @@ fn handle_profile_override<C: VgpuConfigLike>(config: &mut C) -> bool {
     }
 
     if let Some(vmid) = mdev_uuid.and_then(uuid_to_vmid) {
-    	info!("vmid {}", vmid.to_string());
+        info!("vmid {}", vmid.to_string());
     } else {
-	info!("vmid is None");
+        info!("vmid is None");
     }
 
     if let Some(config_override) = config_overrides.profile.get(vgpu_type.as_str()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ use crate::format::WideCharFormat;
 use crate::log::{error, info};
 use crate::nvidia::ctrl0000vgpu::{
     Nv0000CtrlVgpuGetStartDataParams, NV0000_CTRL_CMD_VGPU_GET_START_DATA,
+    Nv0000CtrlVgpuCreateDeviceParams, NV0000_CTRL_CMD_VGPU_CREATE_DEVICE,
 };
 use crate::nvidia::ctrl0080gpu::{
     Nv0080CtrlGpuGetVirtualizationModeParams, NV0080_CTRL_CMD_GPU_GET_VIRTUALIZATION_MODE,
@@ -424,12 +425,20 @@ pub unsafe extern "C" fn ioctl(fd: RawFd, request: c_ulong, argp: *mut c_void) -
                     NV0000_CTRL_CMD_VGPU_GET_START_DATA,
                     Nv0000CtrlVgpuGetStartDataParams
                 ) =>
-            {
+	    {
                 let config: &Nv0000CtrlVgpuGetStartDataParams = &*io_data.params.cast();
-                info!("{:#?}", config);
+	        info!("Nv0000CtrlVgpuGetStartDataParams: {:#?}", config);
 
-                *LAST_MDEV_UUID.lock() = Some(config.mdev_uuid);
+               	*LAST_MDEV_UUID.lock() = Some(config.mdev_uuid);
             }
+    	    NV0000_CTRL_CMD_VGPU_CREATE_DEVICE => {
+		// 17.0 driver provides mdev uuid as vgpu_name in this command
+		let params: &mut Nv0000CtrlVgpuCreateDeviceParams =
+                    &mut *io_data.params.cast();
+	        info!("Nv0000CtrlVgpuCreateDeviceParams: {:#?}", params);
+
+              	*LAST_MDEV_UUID.lock() = Some(params.vgpu_name);
+	    }
             NVA081_CTRL_CMD_VGPU_CONFIG_GET_VGPU_TYPE_INFO => {
                 // 17.0 driver sends larger struct with size 5096 bytes. Only extra members added at the end,
                 // nothing in between or changed, so accessing the larger struct is "safe"
@@ -441,7 +450,7 @@ pub unsafe extern "C" fn ioctl(fd: RawFd, request: c_ulong, argp: *mut c_void) -
                 {
                     let params: &mut NvA081CtrlVgpuConfigGetVgpuTypeInfoParams =
                         &mut *io_data.params.cast();
-                    info!("{:#?}", params);
+                    info!("NvA081CtrlVgpuConfigGetVgpuTypeInfoParams: {:#?}", params);
 
                     if !handle_profile_override(&mut params.vgpu_type_info) {
                         error!("Failed to apply profile override");
@@ -457,7 +466,7 @@ pub unsafe extern "C" fn ioctl(fd: RawFd, request: c_ulong, argp: *mut c_void) -
             {
                 let params: &mut NvA082CtrlCmdHostVgpuDeviceGetVgpuTypeInfoParams =
                     &mut *io_data.params.cast();
-                info!("{:#?}", params);
+                info!("NvA082CtrlCmdHostVgpuDeviceGetVgpuTypeInfoParams: {:#?}", params);
 
                 if !handle_profile_override(params) {
                     error!("Failed to apply profile override");
@@ -527,6 +536,19 @@ fn handle_profile_override<C: VgpuConfigLike>(config: &mut C) -> bool {
 
     let vgpu_type = format!("nvidia-{}", config.vgpu_type());
     let mdev_uuid = LAST_MDEV_UUID.lock().take();
+
+    //output mdev uuid and vmid info
+    if let Some(uuid) = mdev_uuid {
+        info!("mdev_uuid: {}", uuid);
+    } else {
+        info!("mdev_uuid is None");
+    }
+
+    if let Some(vmid) = mdev_uuid.and_then(uuid_to_vmid) {
+    	info!("vmid {}", vmid.to_string());
+    } else {
+	info!("vmid is None");
+    }
 
     if let Some(config_override) = config_overrides.profile.get(vgpu_type.as_str()) {
         info!("Applying profile {} overrides", vgpu_type);

--- a/src/nvidia/ctrl0000vgpu.rs
+++ b/src/nvidia/ctrl0000vgpu.rs
@@ -42,3 +42,26 @@ mod test {
         assert_eq!(mem::size_of::<Nv0000CtrlVgpuGetStartDataParams>(), 0x420);
     }
 }
+
+pub const NV0000_CTRL_CMD_VGPU_CREATE_DEVICE: u32 = 0xc02;
+
+#[repr(C)]
+pub struct Nv0000CtrlVgpuCreateDeviceParams {
+    pub vgpu_name: Uuid,
+    pub gpu_pci_id: u32,
+    pub gpu_pci_bdf: u32,
+    pub vgpu_type_id: u32,
+    pub vgpu_id: u16,
+}
+
+impl fmt::Debug for Nv0000CtrlVgpuCreateDeviceParams {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Nv0000CtrlVgpuCreateDeviceParams")
+            .field("vgpu_name", &format_args!("{{{}}}", self.vgpu_name))
+            .field("gpu_pci_id", &HexFormat(&self.gpu_pci_id))
+            .field("gpu_pci_bdf", &self.gpu_pci_bdf)
+            .field("vgpu_type_id", &self.vgpu_type_id)
+            .field("vgpu_id", &self.vgpu_id)
+            .finish()
+    }
+}

--- a/src/nvidia/ctrl0000vgpu.rs
+++ b/src/nvidia/ctrl0000vgpu.rs
@@ -31,18 +31,6 @@ impl fmt::Debug for Nv0000CtrlVgpuGetStartDataParams {
     }
 }
 
-#[cfg(test)]
-mod test {
-    use std::mem;
-
-    use super::Nv0000CtrlVgpuGetStartDataParams;
-
-    #[test]
-    fn verify_sizes() {
-        assert_eq!(mem::size_of::<Nv0000CtrlVgpuGetStartDataParams>(), 0x420);
-    }
-}
-
 pub const NV0000_CTRL_CMD_VGPU_CREATE_DEVICE: u32 = 0xc02;
 
 #[repr(C)]
@@ -63,5 +51,19 @@ impl fmt::Debug for Nv0000CtrlVgpuCreateDeviceParams {
             .field("vgpu_type_id", &self.vgpu_type_id)
             .field("vgpu_id", &self.vgpu_id)
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::mem;
+
+    use super::Nv0000CtrlVgpuCreateDeviceParams;
+    use super::Nv0000CtrlVgpuGetStartDataParams;
+
+    #[test]
+    fn verify_sizes() {
+        assert_eq!(mem::size_of::<Nv0000CtrlVgpuGetStartDataParams>(), 0x420);
+        assert_eq!(mem::size_of::<Nv0000CtrlVgpuCreateDeviceParams>(), 0x20);
     }
 }


### PR DESCRIPTION
For driver 17.0+ and a patched Tesla P4, NV0000_CTRL_CMD_VGPU_GET_START_DATA doesn't seem to be used; therefore, the mdev_uuid (and vmid if using Proxmox) is never set.  This causes any vm-specific overrides in profile_override.toml to be ignored.

This change adds handling for the NV0000_CTRL_CMD_VGPU_CREATE_DEVICE command if it occurs, which then sets the mdev_uuid.