### PR TITLE
Update params_size check for VGPU_TYPE_INFO

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,7 +452,8 @@ pub unsafe extern "C" fn ioctl(fd: RawFd, request: c_ulong, argp: *mut c_void) -
             NVA081_CTRL_CMD_VGPU_CONFIG_GET_VGPU_TYPE_INFO => {
                 // 18.0 driver sends larger struct with size 5232 bytes, 17.0 driver sends larger struct with size 5096 bytes. Only extra members added at the end,
                 // nothing in between or changed, so accessing the larger struct is "safe"
-                if io_data.params_size == 5232
+                if io_data.params_size == 5424
+                    || io_data.params_size == 5232
                     || io_data.params_size == 5096
                     || check_size!(
                         NVA081_CTRL_CMD_VGPU_CONFIG_GET_VGPU_TYPE_INFO,


### PR DESCRIPTION
Resolves added params_size of 5424 bytes for v19 driver compatibility.

Partially resolves #51 

Unfortunately framebuffer override still isn't working. Happy to test with a bit of support.